### PR TITLE
fix: emit copy of metrics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ class SimpleMetrics implements Metrics, Startable {
         }
       }
 
-      this.onMetrics(output)
+      this.onMetrics(JSON.parse(JSON.stringify(output)))
     })
       .catch(err => {
         log.error('could not invoke onMetrics callback', err)


### PR DESCRIPTION
To prevent observers changing internal state, emit a copy of the metrics.